### PR TITLE
change vcpkg registry protocol to https

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
     "registries": [
         {
             "kind": "git",
-            "repository": "git@github.com:meta-soul/meta-vcpkg-registry.git",
+            "repository": "https://github.com/meta-soul/meta-vcpkg-registry.git",
             "baseline": "5de9b5586e2dd1743ca0846e9209752b0d68c1be",
             "packages": [
                 "onnxruntime-cpu-default"


### PR DESCRIPTION
Change custom vcpkg registry protocol to https to avoid public key denied problem during cpp build