### PR TITLE
[training][bug] fix crash due to statically linking libstdc++

### DIFF
--- a/cmake/metaspore_shared.cmake
+++ b/cmake/metaspore_shared.cmake
@@ -120,12 +120,14 @@ add_library(metaspore_shared SHARED
 )
 set_target_properties(metaspore_shared PROPERTIES PREFIX "")
 set_target_properties(metaspore_shared PROPERTIES OUTPUT_NAME _metaspore)
+set_target_properties(metaspore_shared PROPERTIES
+        BUILD_WITH_INSTALL_RPATH FALSE
+        LINK_FLAGS "-Wl,-rpath,$ORIGIN/")
 target_compile_definitions(metaspore_shared PRIVATE DMLC_USE_S3=1)
 target_compile_definitions(metaspore_shared PRIVATE _METASPORE_VERSION="${project_version}")
 target_compile_definitions(metaspore_shared PRIVATE DBG_MACRO_NO_WARNING)
 target_include_directories(metaspore_shared PRIVATE ${PROJECT_SOURCE_DIR}/cpp)
 target_include_directories(metaspore_shared PRIVATE ${PROJECT_BINARY_DIR}/gen/thrift/cpp)
-target_link_options(metaspore_shared PRIVATE -static-libgcc -static-libstdc++)
 target_link_libraries(metaspore_shared PRIVATE
     metaspore-common
     ${JSON11_LIBRARIES}
@@ -137,4 +139,12 @@ target_link_libraries(metaspore_shared PRIVATE
     Boost::headers
     thrift::thrift
     zmq::libzmq
+)
+
+add_custom_command(TARGET metaspore_shared
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    /lib/x86_64-linux-gnu/libstdc++.so.6 ${CMAKE_BINARY_DIR}/
+    COMMAND ${CMAKE_COMMAND} -E copy
+    /lib/x86_64-linux-gnu/libgcc_s.so.1 ${CMAKE_BINARY_DIR}/
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,6 +20,7 @@
 #   https://stackoverflow.com/questions/42585210/extending-setuptools-extension-to-use-cmake-in-setup-py
 #
 
+import os
 from setuptools import setup
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
@@ -34,7 +35,6 @@ class metaspore_build_ext(build_ext):
             self.build_metaspore(ext)
 
     def get_metaspore_so_path(self):
-        import os
         key = '_METASPORE_SO'
         path = os.environ.get(key)
         if path is None:
@@ -51,9 +51,13 @@ class metaspore_build_ext(build_ext):
         metaspore_so_path = self.get_metaspore_so_path()
         ext_so_path = self.get_ext_fullpath(ext.name)
         shutil.copy(metaspore_so_path, ext_so_path)
+        metaspore_so_dir = os.path.dirname(os.path.realpath(metaspore_so_path))
+        ext_so_dir = os.path.dirname(os.path.realpath(ext_so_path))
+        so_names = ['libstdc++.so.6', 'libgcc_s.so.1']
+        for so_name in so_names:
+            shutil.copy(os.path.join(metaspore_so_dir, so_name), os.path.join(ext_so_dir, so_name))
 
 def get_metaspore_version():
-    import os
     key = '_METASPORE_VERSION'
     metaspore_version = os.environ.get(key)
     if metaspore_version is None:


### PR DESCRIPTION
1. Fix crash inside torch jit due to statically linking libstdc++;
2. Ship libstdc++ and libgcc_s in the python wheel distribution

Closed #42 