### PR TITLE
fix lambda capture warning in gcc build. fix multiple definition ...

### DIFF
--- a/cpp/serving/dense_feature_extraction_model.cpp
+++ b/cpp/serving/dense_feature_extraction_model.cpp
@@ -47,7 +47,7 @@ DenseFeatureExtractionModel::~DenseFeatureExtractionModel() = default;
 awaitable_status DenseFeatureExtractionModel::load(std::string dir_path) {
     auto s = co_await boost::asio::co_spawn(
         Threadpools::get_background_threadpool(),
-        [=]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             namespace fs = std::filesystem;
             for (const auto &entry : fs::directory_iterator(dir_path)) {
                 if (entry.is_regular_file() && entry.path().filename() == "dense_schema.txt") {

--- a/cpp/serving/feature_compute_funcs.cpp
+++ b/cpp/serving/feature_compute_funcs.cpp
@@ -1,3 +1,19 @@
+//
+// Copyright 2022 DMetaSoul
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 #include <common/hash_utils.h>
 #include <serving/arrow_helpers.h>
 #include <serving/feature_compute_funcs.h>
@@ -24,22 +40,6 @@ arrow::Status StringBKDRHashKernelString(cp::KernelContext *ctx, const cp::ExecB
         if (elem.has_value()) {
             if (elem->empty()) {
                 // empty string is treated as null
-//
-// Copyright 2022 DMetaSoul
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-
                 ARROW_RETURN_NOT_OK(builder.AppendNull());
             } else {
                 uint64_t hash = BKDRHash(elem->data(), elem->length(), 0);

--- a/cpp/serving/grpc_server.cpp
+++ b/cpp/serving/grpc_server.cpp
@@ -132,7 +132,7 @@ template <class Handler> struct CoSpawner {
 awaitable<void> respond_error(grpc::ServerAsyncResponseWriter<PredictReply> &writer,
                               const status &s) {
     co_await agrpc::finish_with_error(
-        writer, grpc::Status(static_cast<grpc::StatusCode>(s.code()), (std::string)s.message()),
+        writer, grpc::Status(static_cast<grpc::StatusCode>(s.code()), s.ToString()),
         boost::asio::use_awaitable);
 }
 

--- a/cpp/serving/inmem_sparse_lookup.cpp
+++ b/cpp/serving/inmem_sparse_lookup.cpp
@@ -35,7 +35,7 @@ using namespace std::string_literals;
 awaitable_status InMemorySparseLookupSource::load(const std::string &dir) {
     auto s = co_await boost::asio::co_spawn(
         Threadpools::get_background_threadpool(),
-        [=]() -> awaitable_status {
+        [this, dir]() -> awaitable_status {
             size_t file_count = FileSystemHelpers::count_dat_files(dir);
             if (file_count == 0) {
                 co_return absl::InvalidArgumentError(

--- a/cpp/serving/model_manager.cpp
+++ b/cpp/serving/model_manager.cpp
@@ -37,7 +37,7 @@ void ModelManager::init(const std::string &dir_path) {
         if (dir_entry.is_directory()) {
             boost::asio::co_spawn(
                 Threadpools::get_background_threadpool(),
-                [=]() -> awaitable<void> {
+                [this, dir_entry]() -> awaitable<void> {
                     auto sub_dir = dir_entry.path();
                     auto name = dir_entry.path().filename();
                     spdlog::info("Try to load model from {} with name {} during init", sub_dir,
@@ -58,7 +58,7 @@ void ModelManager::init(const std::string &dir_path) {
 awaitable_status ModelManager::load(const std::string &dir_path, const std::string &name) {
     auto s = co_await boost::asio::co_spawn(
         Threadpools::get_background_threadpool(),
-        [=]() -> awaitable_status {
+        [this, dir_path, name]() -> awaitable_status {
             TabularModel model;
             auto status = co_await model.load(dir_path);
             if (!status.ok()) {

--- a/cpp/serving/ort_model.cpp
+++ b/cpp/serving/ort_model.cpp
@@ -63,7 +63,7 @@ awaitable_status OrtModel::load(std::string dir_path) {
     auto &tp = Threadpools::get_background_threadpool();
     auto r = co_await boost::asio::co_spawn(
         tp,
-        [=]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             auto dir = std::filesystem::path(dir_path);
             if (!std::filesystem::is_directory(dir)) {
                 co_return absl::InvalidArgumentError(

--- a/cpp/serving/sparse_embedding_bag_model.cpp
+++ b/cpp/serving/sparse_embedding_bag_model.cpp
@@ -42,7 +42,7 @@ awaitable_status SparseEmbeddingBagModel::load(std::string dir_path) {
     auto &tp = Threadpools::get_background_threadpool();
     auto r = co_await boost::asio::co_spawn(
         tp,
-        [=]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             auto status = co_await context_->ort_model_.load(dir_path);
             if (!status.ok()) {
                 spdlog::error("Cannot load embedding bag ort model from {}", dir_path);

--- a/cpp/serving/sparse_feature_extraction_model.cpp
+++ b/cpp/serving/sparse_feature_extraction_model.cpp
@@ -48,7 +48,7 @@ SparseFeatureExtractionModel::~SparseFeatureExtractionModel() = default;
 awaitable_status SparseFeatureExtractionModel::load(std::string dir_path) {
     auto s = co_await boost::asio::co_spawn(
         Threadpools::get_background_threadpool(),
-        [=]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             std::filesystem::path p(dir_path);
             std::filesystem::path schema_file = p / "combine_schema.txt";
             if (!std::filesystem::is_regular_file(schema_file)) {

--- a/cpp/serving/sparse_lookup_model.cpp
+++ b/cpp/serving/sparse_lookup_model.cpp
@@ -49,7 +49,7 @@ awaitable_status SparseLookupModel::load(std::string dir_path) {
     auto &tp = Threadpools::get_background_threadpool();
     auto r = co_await boost::asio::co_spawn(
         tp,
-        [=]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             std::filesystem::path p(dir_path);
             if (!std::filesystem::is_directory(p)) {
                 co_return absl::NotFoundError(

--- a/cpp/serving/tabular_model.cpp
+++ b/cpp/serving/tabular_model.cpp
@@ -60,7 +60,7 @@ TabularModel::~TabularModel() = default;
 awaitable_status TabularModel::load(std::string dir_path) {
     auto s = co_await boost::asio::co_spawn(
         Threadpools::get_background_threadpool(),
-        [&]() -> awaitable_status {
+        [this, dir_path]() -> awaitable_status {
             // load a ctr model
             // 1. find all subdirs prefixed with "sparse_" and load fe/lookup models in them
             fs::path root_dir(dir_path);

--- a/python/tests/sparse_wdl_export_demo.py
+++ b/python/tests/sparse_wdl_export_demo.py
@@ -69,6 +69,7 @@ emb_names = []
 for name, mod in module.named_children():
     if isinstance(mod, ms.embedding.EmbeddingOperator):
         emb_names.append(name)
+        mod.export_sparse_embedding_bag('emb_output', 'emb')
 
 from torch.fx import Tracer, GraphModule 
 


### PR DESCRIPTION
of absl::Status:: multiple definition of `absl::lts_20211102::Status::kMovedFromString.

Closed #43 