### PR TITLE
fix get wheel version in cmake. reduce build env image size

### DIFF
--- a/cmake/get_python_wheel_name.cmake
+++ b/cmake/get_python_wheel_name.cmake
@@ -32,10 +32,11 @@ function(get_python_wheel_name var)
         message(FATAL_ERROR "Can not get Python wheel tag.")
     endif()
     execute_process(
-        COMMAND ${Python_EXECUTABLE} -c "import pkg_resources; print(pkg_resources.get_distribution('metaspore').version, end='')"
+        COMMAND bash "-c" "grep --color=never version pyproject.toml | grep --color=never -Eo '[0-9\.]+'"
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         RESULT_VARIABLE rc
-        OUTPUT_VARIABLE wheel_version)
+        OUTPUT_VARIABLE wheel_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT "${rc}" STREQUAL "0" OR "${wheel_version}" STREQUAL "")
         message(FATAL_ERROR "Can not get Python wheel version.")
     endif()

--- a/docker/py_wheel_manylinux2014_env.dockerfile
+++ b/docker/py_wheel_manylinux2014_env.dockerfile
@@ -3,6 +3,6 @@ FROM quay.io/pypa/manylinux2014_x86_64
 RUN yum update -y && yum install -y curl zip unzip tar perl-IPC-Cmd flex && yum clean packages
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
 RUN /opt/vcpkg/bootstrap-vcpkg.sh
-COPY vcpkg.json /opt/vcpkg.json
-COPY vcpkg-configuration.json /opt/vcpkg-configuration.json
+COPY vcpkg-wheel.json /opt/vcpkg.json
+RUN echo "set(VCPKG_BUILD_TYPE release)" >> /opt/vcpkg/triplets/x64-linux.cmake
 RUN PATH=/opt/python/cp38-cp38/bin:$PATH && LD_LIBRARY_PATH=/opt/python/cp38-cp38/lib:$LD_LIBRARY_PATH && /opt/vcpkg/vcpkg install --x-install-root=/opt/vcpkg_installed --x-manifest-root=/opt --clean-after-build

--- a/docker/ubuntu20.04/Dockerfile_dev
+++ b/docker/ubuntu20.04/Dockerfile_dev
@@ -59,4 +59,5 @@ RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
 RUN /opt/vcpkg/bootstrap-vcpkg.sh
 COPY vcpkg.json /opt/vcpkg.json
 COPY vcpkg-configuration.json /opt/vcpkg-configuration.json
+RUN echo "set(VCPKG_BUILD_TYPE release)" >> /opt/vcpkg/triplets/x64-linux.cmake
 RUN --mount=type=cache,target=/opt/vcpkg_installed /opt/vcpkg/vcpkg install --x-install-root=/opt/vcpkg_installed --x-manifest-root=/opt --clean-after-build

--- a/vcpkg-wheel.json
+++ b/vcpkg-wheel.json
@@ -1,0 +1,33 @@
+{
+    "name": "metaspore",
+    "version": "1.0.0",
+    "dependencies": [
+        "boost-filesystem",
+        "boost-system",
+        "fmt",
+        "spdlog",
+        "gflags",
+        "cppzmq",
+        "python3",
+        "pybind11",
+        "json11",
+        "thrift",
+        {
+            "name": "aws-sdk-cpp",
+            "features": [
+                "s3"
+            ]
+        },
+        "zeromq",
+        "dbg-macro",
+        "zlib"
+    ],
+    "overrides": [
+        {
+            "name": "python3",
+            "version": "3.8.3",
+            "port-version": 2
+        }
+    ],
+    "builtin-baseline": "e2794913924ef606cc7bbc59c173f2714e9853c5"
+}


### PR DESCRIPTION
Close #179 
1. Fix get wheel version in cmake
2. Use release build only for vcpkg to reduce build env image size