### PR TITLE
Specify the dimension of squeeze function in din model 

### DIFF
--- a/demo/ctr/din/conf/din_ml_1m.yaml
+++ b/demo/ctr/din/conf/din_ml_1m.yaml
@@ -11,16 +11,16 @@ server_memory: '5G'
 coordinator_memory: '5G'
 
 ## datasets
-train_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/train.parquet
-test_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/test.parquet
+train_path: ${MY_S3_BUCKET}/movielens/1m/rank/train.parquet
+test_path: ${MY_S3_BUCKET}/movielens/1m/rank/test.parquet
 
 ## model configurations
-din_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
-din_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema.txt
-wide_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
-wide_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema_wide.txt
-deep_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
-deep_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema_deep.txt
+din_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
+din_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema.txt
+wide_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
+wide_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema_wide.txt
+deep_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
+deep_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema_deep.txt
 
 model_in_path: null
 model_out_path: ${MY_S3_BUCKET}/movielens/model/din/model_out/ml_1m/

--- a/demo/ctr/din/conf/din_ml_1m.yaml
+++ b/demo/ctr/din/conf/din_ml_1m.yaml
@@ -11,16 +11,16 @@ server_memory: '5G'
 coordinator_memory: '5G'
 
 ## datasets
-train_path: ${MY_S3_BUCKET}/movielens/1m/rank/train.parquet
-test_path: ${MY_S3_BUCKET}/movielens/1m/rank/test.parquet
+train_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/train.parquet
+test_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/test.parquet
 
 ## model configurations
-din_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
-din_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema.txt
-wide_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
-wide_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema_wide.txt
-deep_column_name_path: ${MY_S3_BUCKET}/movielens/1m/rank/column_schema_DIN.txt
-deep_combine_schema_path: ${MY_S3_BUCKET}/movielens/1m/rank/combine_column_schema_deep.txt
+din_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
+din_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema.txt
+wide_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
+wide_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema_wide.txt
+deep_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/column_schema_DIN.txt
+deep_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/1m/rank/combine_column_schema_deep.txt
 
 model_in_path: null
 model_out_path: ${MY_S3_BUCKET}/movielens/model/din/model_out/ml_1m/
@@ -56,3 +56,4 @@ ftrl_l2: 120.0
 ftrl_alpha: 0.5
 ftrl_beta: 1.0
 adam_learning_rate: 0.0001
+train_epoches: 10

--- a/demo/ctr/din/conf/din_ml_25m.yaml
+++ b/demo/ctr/din/conf/din_ml_25m.yaml
@@ -11,16 +11,16 @@ server_memory: '10G'
 coordinator_memory: '10G'
 
 ## datasets
-train_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/train.parquet
-test_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/test.parquet
+train_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/train.parquet
+test_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/test.parquet
 
 ## model configurations
-din_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
-din_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_din_25M.txt
-wide_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
-wide_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_wide.txt
-deep_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
-deep_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_deep.txt
+din_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
+din_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_din_25M.txt
+wide_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
+wide_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_wide.txt
+deep_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
+deep_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_deep.txt
 
 model_in_path: null
 model_out_path: ${MY_S3_BUCKET}/movielens/model/din/model_out/ml_1m/
@@ -56,3 +56,4 @@ ftrl_l2: 120.0
 ftrl_alpha: 0.5
 ftrl_beta: 1.0
 adam_learning_rate: 0.0001
+train_epoches: 1

--- a/demo/ctr/din/conf/din_ml_25m.yaml
+++ b/demo/ctr/din/conf/din_ml_25m.yaml
@@ -11,16 +11,16 @@ server_memory: '10G'
 coordinator_memory: '10G'
 
 ## datasets
-train_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/train.parquet
-test_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/test.parquet
+train_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/train.parquet
+test_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/test.parquet
 
 ## model configurations
-din_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
-din_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_din_25M.txt
-wide_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
-wide_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_wide.txt
-deep_column_name_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/column_schema_din_25M.txt
-deep_combine_schema_path: s3://dmetasoul-bucket/xwb/demo/movielens/25m/rank-seq/combine_schema_deep.txt
+din_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
+din_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_din_25M.txt
+wide_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
+wide_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_wide.txt
+deep_column_name_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/column_schema_din_25M.txt
+deep_combine_schema_path: ${MY_S3_BUCKET}/movielens/25m/rank-seq/combine_schema_deep.txt
 
 model_in_path: null
 model_out_path: ${MY_S3_BUCKET}/movielens/model/din/model_out/ml_1m/

--- a/demo/ctr/din/din.py
+++ b/demo/ctr/din/din.py
@@ -113,7 +113,8 @@ def train(spark, trian_dataset, **model_params):
                                   model_version=model_version,
                                   experiment_name=experiment_name,
                                   input_label_column_index=input_label_column_index,
-                                  metric_update_interval=metric_update_interval) #100
+                                  metric_update_interval=metric_update_interval,
+                                  train_epoches=train_epoches) #100
     model = estimator.fit(trian_dataset)
      ## dnn learning rate
     estimator.updater = ms.AdamTensorUpdater(adam_learning_rate)

--- a/python/algos/sequential/din/din_net.py
+++ b/python/algos/sequential/din/din_net.py
@@ -127,7 +127,7 @@ class DIN(torch.nn.Module):
         all_column_embedding = []
         for column_index in non_seq_column_index_list:
             column_embedding = x_reshape[column_index::column_nums]
-            column_embedding = torch.stack(column_embedding).squeeze()
+            column_embedding = torch.stack(column_embedding).squeeze(1)
             all_column_embedding.append(column_embedding)
         all_column_embedding = torch.cat(all_column_embedding, dim=1) 
         return all_column_embedding
@@ -153,7 +153,7 @@ class DIN(torch.nn.Module):
         target_embedding = self.get_non_seq_column_embedding(self.target_column_index_list, x_reshape, column_nums)  
         seq_embedding = self.get_seq_column_embedding(self.seq_column_index_list, x_reshape, column_nums)
         item_seq_length = self.get_seq_length(self.seq_column_index_list, x, offset, column_nums)
-        all_sum_pooling = self.DIN_attention(target_embedding, seq_embedding, item_seq_length).squeeze()
+        all_sum_pooling = self.DIN_attention(target_embedding, seq_embedding, item_seq_length).squeeze(1)
         emb_concat = torch.cat((other_embedding, all_sum_pooling, target_embedding), dim=1)     
         din_out = self.mlp(emb_concat) 
         if self.use_wide:


### PR DESCRIPTION
1. Squeeze function returns a tensor with all the dimensions of input of size 1 removed.  It is better to specify the dimension if you want to remove some one dimension, otherwise it may squeeze two or more dimensions. close #209 
2.  The parameter of `train_epoches` will help the model get good performance.